### PR TITLE
Enable README at Organizational level

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,23 @@
+# Overview
+The Supply Chain Integrity, Transparency and Trust (SCITT) community is a group of SCITT enthusiasts focused on adoption of [IETF SCITT specifications](https://datatracker.ietf.org/wg/scitt) via implementations, tooling, testing, advocacy, outreach and interoperability. SCITT community is fully open and new members are welcome to participate. 
+
+# Our Goal 
+To work as a community to facilitate adoption of IETF Supply Chain Integrity, Transparency & Trust (SCITT) specifications.
+
+# Contributing
+
+## Mailing List:
++ Join the SCITT community mailing list at https://groups.io/g/scitt-community
+
+## SCITT Community Meetings:
++ SCITT Community Meetings: We are working on scheduling our kickoff meeting. Cadence and time of meeting to be discussed during kickoff meeting
+- Link to meeting agenda, prior meeting notes and meeting videos will be made available
+
+## SCITT Community Resources:
++ Website for SCITT Community: [scitt.io](https://scitt.io)
+
+## IETF SCITT Working Group Resources:
++ IETF SCITT Working Group GitHub Org- https://github.com/ietf-scitt 
++ IETF SCITT Working Group Documents: https://datatracker.ietf.org/wg/scitt/documents/ 
++ IETF Working Group Meetings: https://datatracker.ietf.org/wg/scitt/meetings/ 
+ 


### PR DESCRIPTION
Now that we have officially announced SCITT community, this PR enables the README at organizational level